### PR TITLE
specify package manager explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ See also [Fiftyone JS Plugin Build Utils](https://github.com/voxel51/fiftyone-js
 
 ### `yarn` or `yarn install` fails
 
-1. Make sure you have the right version of `yarn` in your `PATH`. You can check the version by running `yarn --version`. If you have `corepack` installed (available by default in node v16+), you'll be auto prompoted to install the right version of `yarn` when you run `yarn` or `yarn install` in the plugin directory.
+1. Make sure you have the right version of `yarn` in your `PATH`. You can check the version by running `yarn --version`. If you have `corepack` installed (available by default in node v16+), you'll be auto prompted to install the right version of `yarn` when you run `yarn` or `yarn install` in the plugin directory.

--- a/README.md
+++ b/README.md
@@ -56,3 +56,9 @@ export default defineConfig(dir, {
 Before running `yarn build`, make sure you have a local copy of FiftyOne and `FIFTYONE_DIR` is set to the root of the FiftyOne repository.
 
 See also [Fiftyone JS Plugin Build Utils](https://github.com/voxel51/fiftyone-js-plugin-build).
+
+## Troubleshooting
+
+### `yarn` or `yarn install` fails
+
+1. Make sure you have the right version of `yarn` in your `PATH`. You can check the version by running `yarn --version`. If you have `corepack` installed (available by default in node v16+), you'll be auto prompoted to install the right version of `yarn` when you run `yarn` or `yarn install` in the plugin directory.

--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
     "@fiftyone/relay": "portal:../fiftyone/app/packages/relay",
     "@fiftyone/operators": "portal:../fiftyone/app/packages/operators",
     "@fiftyone/plugins": "portal:../fiftyone/app/packages/plugins"
-  }
+  },
+  "packageManager": "yarn@4.5.0"
 }


### PR DESCRIPTION
Lower versions of yarn do not support the [`portal` protocol](https://yarnpkg.com/protocol/portal). This PR explicitly specifies pacakge manager version in `package.json` so that users do not get inexplicable errors when running `yarn install`.